### PR TITLE
Move path stuff out of uvv8

### DIFF
--- a/path/BUCK
+++ b/path/BUCK
@@ -1,0 +1,16 @@
+cxx_library(
+  name = 'path',
+  header_namespace = 'path',
+  exported_headers = subdir_glob([
+    ('include', '**/*.hh'),
+  ]),
+  srcs = glob([
+    'src/**/*.cc',
+  ]),
+  visibility = [
+    '//...',
+  ],
+  compiler_flags = [
+    '-std=c++1z',
+  ],
+)

--- a/path/include/path.hh
+++ b/path/include/path.hh
@@ -7,10 +7,13 @@
 #include <iostream>
 #include <sstream>
 #include <algorithm>
+#include <cassert>
 
 #include <uv.h>
 
-#include "uvv8/util/check.hh"
+#ifndef CHECK
+#define CHECK(condition) assert(condition)
+#endif
 
 bool IsAbsolutePath(const std::string& path);
 
@@ -24,8 +27,6 @@ std::string DirName(const std::string& path);
 // and replacing backslashes with slashes).
 std::string NormalizePath(const std::string& path,
                           const std::string& dir_name);
-
-const std::string& ReadFile(const std::string& path);
 
 // const std::string ResolveRelative(const std::string& path,
 //                            const std::string& base,

--- a/path/src/path.cc
+++ b/path/src/path.cc
@@ -1,4 +1,4 @@
-#include "uvv8/util/path.hh"
+#include "path/path.hh"
 
 bool starts_with(const std::string &str, const std::string &suffix) {
   return str.size() >= suffix.size()
@@ -31,9 +31,9 @@ std::string GetWorkingDirectory() {
 
 // Returns the directory part of path, without the trailing '/'.
 std::string DirName(const std::string& path) {
-  DCHECK(IsAbsolutePath(path));
+  CHECK(IsAbsolutePath(path));
   size_t last_slash = path.find_last_of('/');
-  DCHECK(last_slash != std::string::npos);
+  CHECK(last_slash != std::string::npos);
   return path.substr(0, last_slash);
 }
 
@@ -42,7 +42,6 @@ std::string DirName(const std::string& path) {
 // and replacing backslashes with slashes).
 std::string NormalizePath(const std::string& path,
                           const std::string& dir_name) {
-
   std::cout << "normalizing path: " << path << ", dir: " << dir_name << std::endl;
   std::string result;
   if (IsAbsolutePath(path)) {
@@ -161,12 +160,3 @@ std::string NormalizePath(const std::string& path,
 //
 //   return nullptr;
 // }
-
-const std::string& ReadFile(const std::string& path) {
-  std::ifstream it(path.c_str());
-  const std::string* contents = new std::string(
-    (std::istreambuf_iterator<char>(it)),
-    std::istreambuf_iterator<char>()
-  );
-  return *contents;
-}

--- a/river/src/module-loader.cc
+++ b/river/src/module-loader.cc
@@ -3,6 +3,15 @@
 
 using namespace v8;
 
+const std::string& ReadFile(const std::string& path) {
+  std::ifstream it(path.c_str());
+  const std::string* contents = new std::string(
+    (std::istreambuf_iterator<char>(it)),
+    std::istreambuf_iterator<char>()
+  );
+  return *contents;
+}
+
 //
 // Private
 //

--- a/uvv8/BUCK
+++ b/uvv8/BUCK
@@ -30,6 +30,7 @@ cxx_library(
   ],
   deps = [
     ':linker_flags',
-    '//deps/libuv:libuv'
+    '//deps/libuv:libuv',
+    '//path:path'
   ]
 )

--- a/uvv8/include/uvv8.hh
+++ b/uvv8/include/uvv8.hh
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <path/path.hh>
+
 #include <uvv8/util/check.hh>
 #include <uvv8/util/convert.hh>
 #include <uvv8/util/exceptions.hh>
-#include <uvv8/util/path.hh>
 
 #include <uvv8/fs.hh>


### PR DESCRIPTION
I've pulled the path stuff out to a separate module so it can be constructed more generically.